### PR TITLE
Add better message for NoMatchError

### DIFF
--- a/lib/kase/switcher.rb
+++ b/lib/kase/switcher.rb
@@ -29,7 +29,7 @@ module Kase
     end
 
     def validate!
-      raise NoMatchError unless matched?
+      raise NoMatchError.new(@values) unless matched?
       true
     end
 

--- a/spec/switcher_spec.rb
+++ b/spec/switcher_spec.rb
@@ -89,9 +89,10 @@ module Kase
 
     describe "#validate!" do
       it "raises NoMatchError if not matched" do
+        values = [:error, :unknown]
         expect {
-          Switcher.new.validate!
-        }.to raise_error(NoMatchError)
+          Switcher.new(values).validate!
+        }.to raise_error(NoMatchError, values.inspect)
       end
 
       it "returns true if matched" do


### PR DESCRIPTION
The current `NoMatchError` is opaque when it comes to figuring out when something is not matching. This patch makes it clearer what is trying to be matched.
