### PR TITLE
More simple DSL that just defines the on method in block context, 6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Next
 
+* Simpler and safer DSL that runs in the context of the calling code,
+[#6](https://github.com/lasseebert/kase/issues/6),
+[lasseebert](https://github.com/lasseebert) and [hosh](https://github.com/hosh)
 * (Your contributions here)
 
 # Version 0.1.2 (2016-04-06)

--- a/lib/kase/switcher.rb
+++ b/lib/kase/switcher.rb
@@ -71,7 +71,7 @@ module Kase
         if method
           context.define_singleton_method(:on, method)
         else
-          context.instance_eval { undef :on }
+          context.instance_eval { undef :on if defined? on }
         end
       end
     end

--- a/lib/kase/switcher.rb
+++ b/lib/kase/switcher.rb
@@ -49,8 +49,8 @@ module Kase
         original_on = context.method(:on) if defined? context.on
 
         # Define new on method
-        context.define_singleton_method(:on) do |*pattern, &block|
-          switcher.on(*pattern, &block)
+        context.define_singleton_method(:on) do |*pattern, &inner_block|
+          switcher.on(*pattern, &inner_block)
         end
 
         block.call

--- a/spec/switcher_spec.rb
+++ b/spec/switcher_spec.rb
@@ -209,6 +209,14 @@ module Kase
 
         expect(result).to eq("original")
       end
+
+      it "handles errors" do
+        expect {
+          Switcher.new(:ok).switch do
+            on(:ok) { raise "BOOM" }
+          end
+        }.to raise_error(/BOOM/)
+      end
     end
   end
 end

--- a/spec/switcher_spec.rb
+++ b/spec/switcher_spec.rb
@@ -165,6 +165,32 @@ module Kase
 
         expect(result).to eq("RESULT")
       end
+
+      it "does not leak DSL on method" do
+        Switcher.new(:ok).switch do
+          on(:ok) { 42 }
+        end
+
+        expect { on }.to raise_error(NameError)
+      end
+
+      it "does not overwrite on method" do
+        klass = Class.new do
+          def on
+            "original"
+          end
+
+          def call
+            Switcher.new(:ok).switch do
+              on(:ok) { 42 }
+            end
+          end
+        end
+        instance = klass.new
+        instance.call
+
+        expect(instance.on).to eq("original")
+      end
     end
   end
 end

--- a/spec/switcher_spec.rb
+++ b/spec/switcher_spec.rb
@@ -191,6 +191,24 @@ module Kase
 
         expect(instance.on).to eq("original")
       end
+
+      it "can use original :on method inside on block" do
+        klass = Class.new do
+          def on
+            "original"
+          end
+
+          def call
+            Switcher.new(:ok).switch do
+              on(:ok) { on }
+            end
+          end
+        end
+        instance = klass.new
+        result = instance.call
+
+        expect(result).to eq("original")
+      end
     end
   end
 end


### PR DESCRIPTION
Ref #6 

This new DSL has the same public API, but works differently underneath.

It simply replaces the `on` method on the caller context and restores it after the block call (if it was defined).
